### PR TITLE
fix(bug): enable input value reset, remove deprecated defaultProps, u…

### DIFF
--- a/lib/components/MaskedInput/MaskedInput.tsx
+++ b/lib/components/MaskedInput/MaskedInput.tsx
@@ -137,10 +137,4 @@ export class MaskedInput extends React.PureComponent<Props, State> {
   }
 }
 
-MaskedInput.defaultProps = {
-  mask: [],
-  render: (ref, props) => <input ref={ref} {...props} />,
-  type: 'text',
-};
-
 export { default as conformToMask } from '../../core/conformToMask.js';

--- a/lib/core/createTextMaskInputElement.ts
+++ b/lib/core/createTextMaskInputElement.ts
@@ -51,7 +51,7 @@ export default function createTextMaskInputElement(config: MainConfig): TextMask
 
       // If `rawValue` equals `state.previousConformedValue`, we don't need to change anything. So, we return.
       // This check is here to handle controlled framework components that repeat the `update` call on every render.
-      if (rawValue === state.previousConformedValue) {
+      if (rawValue === state.previousConformedValue && rawValue !== '') {
         return;
       }
 
@@ -229,6 +229,6 @@ function getSafeRawValue(inputValue: string | number): string {
 
   throw new Error(
     "The 'value' provided to Text Mask needs to be a string or a number. The value " +
-      `received was:\n\n ${JSON.stringify(inputValue)}`,
+    `received was:\n\n ${JSON.stringify(inputValue)}`,
   );
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": ">=16.8.0 <19",
+    "react-dom": ">=16.8.0 <19"
   }
 }


### PR DESCRIPTION
…pdate React peer dependencies

- Added functionality to reset the input value in MaskedInput component
- Removed MaskedInput.defaultProps as it has been deprecated
- Updated React peer dependencies to support versions between 16 and 18